### PR TITLE
Ruby 1.9 Fix

### DIFF
--- a/lib/collectd/interface.rb
+++ b/lib/collectd/interface.rb
@@ -209,7 +209,7 @@ module Collectd
         @gauges = {}
 
         # And return serialized packet of parts
-        pkt.to_s
+        pkt.join
       end
     end
 


### PR DESCRIPTION
Default to_s on Array is now same as inspect.

to_s: bytes: 128 body: "[\x00...\x00L@]"
join: bytes: 112 body: "\x00...\x00L@"

When using to_s chart does not work, collectd is adding to log:
[2013-03-07 18:50:34] network plugin: parse_packet: Received truncated packet, try increasing `MaxPacketSize'

Changing to_s -> join is fixing problem.